### PR TITLE
Only invoke onChanged if not null

### DIFF
--- a/lib/src/radio_button.dart
+++ b/lib/src/radio_button.dart
@@ -19,7 +19,11 @@ class RadioButton<T> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => InkWell(
-        onTap: () => this.onChanged(value),
+        onTap: () {
+          if(this.onChanged != null){
+            this.onChanged(value);
+          }
+        },
         child: Row(
           mainAxisAlignment: this.textPosition == RadioButtonTextPosition.right
               ? MainAxisAlignment.start


### PR DESCRIPTION
Fixes bug "The method 'call' was called on null." when `onChanged` is set to null to make Radios readonly